### PR TITLE
`search()` の引数と戻り値の型をexport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { isRecorded, record } from "./record";
 export { search } from "./search";
+export { SearchParam, SearchResult } from "./types";


### PR DESCRIPTION
Fixes #5