### PR TITLE
エピソードタイトルの一致判定で記号等の違いは無視する

### DIFF
--- a/src/util/normalize.test.ts
+++ b/src/util/normalize.test.ts
@@ -1,4 +1,4 @@
-import { normalize, normalizeAll } from "./normalize";
+import { normalize } from "./normalize";
 
 describe("normalize", () => {
 	test("響け！ユーフォニアム２", () => {
@@ -13,47 +13,5 @@ describe("normalize", () => {
 				remove: { anime: true, movie: true, bracket: true },
 			}),
 		).toBe("響け！ユーフォニアム～誓いのフィナーレ～");
-	});
-});
-
-describe("normalizeAll", () => {
-	test("響け！ユーフォニアム２", () => {
-		expect(normalizeAll("響け！ユーフォニアム２")).toBe("響け!ユーフォニアム2");
-	});
-
-	test("響け！ユーフォニアム　2", () => {
-		expect(normalizeAll("響け！ユーフォニアム　2")).toBe(
-			"響け!ユーフォニアム2",
-		);
-	});
-
-	test("「響け！ユーフォニアム」", () => {
-		expect(normalizeAll("響け！ユーフォニアム")).toBe("響け!ユーフォニアム");
-	});
-
-	test("アニメ「響け！ユーフォニアム」", () => {
-		expect(normalizeAll("響け！ユーフォニアム")).toBe("響け!ユーフォニアム");
-	});
-
-	test("劇場版 響け！ユーフォニアム～誓いのフィナーレ～", () => {
-		expect(
-			normalizeAll("劇場版 響け！ユーフォニアム～誓いのフィナーレ～"),
-		).toBe("劇場版響け!ユーフォニアム~誓いのフィナーレ~");
-	});
-
-	test("劇場版 響け！ユーフォニアム〜誓いのフィナーレ〜 - 波ダッシュ(U+301C)", () => {
-		expect(
-			normalizeAll("劇場版 響け！ユーフォニアム〜誓いのフィナーレ〜"),
-		).toBe("劇場版響け!ユーフォニアム~誓いのフィナーレ~");
-	});
-
-	test("ゆるキャン△ SEASON２", () => {
-		expect(normalizeAll("ゆるキャン△ SEASON２")).toBe("ゆるキャン△season2");
-	});
-
-	test("やはり俺の青春ラブコメはまちがっている｡ - 半角句点", () => {
-		expect(normalizeAll("やはり俺の青春ラブコメはまちがっている｡")).toBe(
-			"やはり俺の青春ラブコメはまちがっている。",
-		);
 	});
 });

--- a/src/util/normalize.ts
+++ b/src/util/normalize.ts
@@ -129,8 +129,8 @@ export function normalize(title: string, options?: Options): string {
 	return normalizedTitle;
 }
 
-export function normalizeAll(str: string): string {
-	return normalize(str, {
+export function isSameTitle(a: string, b: string, weak = false): boolean {
+	const options = {
 		lowerCase: true,
 		zenhan: {
 			alphabet: true,
@@ -149,10 +149,8 @@ export function normalizeAll(str: string): string {
 			space: true,
 			anime: true,
 			bracket: true,
+			nonNumAndLetter: weak,
 		},
-	});
-}
-
-export function isSameTitle(a: string, b: string): boolean {
-	return normalizeAll(a) === normalizeAll(b);
+	};
+	return normalize(a, options) === normalize(b, options);
 }

--- a/src/util/search/find-episode.ts
+++ b/src/util/search/find-episode.ts
@@ -9,7 +9,9 @@ export function findEpisode(
 	// タイトルが一致するエピソード
 	const episodeByTitle = episodes.find(
 		(episode) =>
-			episode.title && target.title && isSameTitle(episode.title, target.title),
+			episode.title &&
+			target.title &&
+			isSameTitle(episode.title, target.title, true),
 	);
 	if (episodeByTitle) {
 		return episodeByTitle;
@@ -25,7 +27,7 @@ export function findEpisode(
 		(episode) =>
 			episode.numberText &&
 			target.numberText &&
-			isSameTitle(episode.numberText, target.numberText),
+			isSameTitle(episode.numberText, target.numberText, true),
 	);
 	if (episodeByNumberText) {
 		return episodeByNumberText;


### PR DESCRIPTION
Fixes #13