### PR TITLE
丸数字（①-㊿）の数値パース機能を追加

### DIFF
--- a/src/util/extract/number.test.ts
+++ b/src/util/extract/number.test.ts
@@ -87,6 +87,30 @@ describe("ローマ数字", () => {
 	});
 });
 
+describe("丸数字", () => {
+	test("①", () => {
+		expect(parseNumber("①")).toBe(1);
+	});
+	test("⑨", () => {
+		expect(parseNumber("⑨")).toBe(9);
+	});
+	test("⑩", () => {
+		expect(parseNumber("⑩")).toBe(10);
+	});
+	test("⑳", () => {
+		expect(parseNumber("⑳")).toBe(20);
+	});
+	test("㉑", () => {
+		expect(parseNumber("㉑")).toBe(21);
+	});
+	test("㊿", () => {
+		expect(parseNumber("㊿")).toBe(50);
+	});
+	test("①②", () => {
+		expect(parseNumber("①②")).toBe(undefined);
+	});
+});
+
 describe("無効な入力", () => {
 	test("", () => {
 		expect(parseNumber("")).toBe(undefined);

--- a/src/util/extract/number.ts
+++ b/src/util/extract/number.ts
@@ -47,6 +47,25 @@ function roman(str: string): number | undefined {
 	}
 }
 
+const circledNumbers =
+	"①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳㉑㉒㉓㉔㉕㉖㉗㉘㉙㉚㉛㉜㉝㉞㉟㊱㊲㊳㊴㊵㊶㊷㊸㊹㊺㊻㊼㊽㊾㊿";
+
+function circle(str: string): number | undefined {
+	const match = str.match(numMatch.circle);
+	if (!match) {
+		return;
+	}
+	const circleChar = match[0];
+	// "①②" のような複数文字に対応しない
+	if ([...circleChar].length > 1) {
+		return;
+	}
+	const num = circledNumbers.indexOf(circleChar);
+	if (num !== -1) {
+		return num + 1;
+	}
+}
+
 export function parseNumber(str: string): number | undefined {
-	return normal(str) || zen(str) || kansuji(str) || roman(str);
+	return normal(str) || zen(str) || kansuji(str) || roman(str) || circle(str);
 }

--- a/src/util/match.ts
+++ b/src/util/match.ts
@@ -2,12 +2,14 @@ const zen = "０-９";
 const kanji =
 	"〇一二三四五六七八九十百千零壱壹弐弍貳貮参參肆伍陸漆捌玖拾廿陌佰阡仟";
 const roman = "IVXLCDM";
+const circle =
+	"①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮⑯⑰⑱⑲⑳㉑㉒㉓㉔㉕㉖㉗㉘㉙㉚㉛㉜㉝㉞㉟㊱㊲㊳㊴㊵㊶㊷㊸㊹㊺㊻㊼㊽㊾㊿";
 
 const numChars = {
 	zen,
 	kanji,
 	roman,
-	all: `\\d${zen}${kanji}${roman}`,
+	all: `\\d${zen}${kanji}${roman}${circle}`,
 };
 
 const num = `[${numChars.all}]+`;
@@ -17,6 +19,7 @@ export const numMatch = {
 	zen: /[０-９]+/g,
 	kanji: new RegExp(`[${kanji}]+`, "g"),
 	roman: new RegExp(`[${roman}]+`, "g"),
+	circle: new RegExp(`[${circle}]+`, "g"),
 	all: new RegExp(`[${numChars.all}]+`, "g"),
 };
 


### PR DESCRIPTION
## Summary
- 丸数字文字列（①-㊿）を数値に変換する機能を実装
- parseNumber関数に新しいcircle関数を追加し統合
- テストケースを追加して動作を検証

Closes #24